### PR TITLE
FormBuilder's component edit view

### DIFF
--- a/addKeySetter.js
+++ b/addKeySetter.js
@@ -1,0 +1,41 @@
+import { Formio } from "formiojs";
+
+function findComponents(components, target) {
+    for (let i = 0; i < components.length; i++) {
+        if (components[i].key === target)
+            return components[i];
+    }
+    return undefined;
+}
+
+for (let comp in Formio.Components.components) {
+    if (comp !== "unknown" && Formio.Components.components[comp].editForm !== undefined) {
+        const editForm = Formio.Components.components[comp].editForm();
+        const tabs = findComponents(editForm.components, "tabs");
+        if (tabs === undefined)
+            continue;
+        const api = findComponents(tabs.components, "api");
+        if (api === undefined)
+            continue;
+        api.components[0].disabled = true;
+        api.components[0].validate = {
+            "required": true,
+            "custom": "if (input !== \"\") {\n  valid = /^\\w[\\w.-]*\\w$/.test(input) ? true : \"The property name must only contain alphanumeric characters, underscores, dots and dashes and should not be ended by dash or dot.\";\n}"
+        };
+        api.components = [
+            {
+                "weight": 0,
+                "type": "textfield",
+                "input": true,
+                "key": "keySetter",
+                "label": "Key Setter",
+                "tooltip": "This is used for setting up the Property Name",
+                "calculateValue": "instance.parent.getComponent(\"key\").setValue(value);"
+            },
+            ...api.components
+        ];
+        Formio.Components.components[comp].editForm = function () {
+            return editForm;
+        }
+    }
+}

--- a/index.html
+++ b/index.html
@@ -6,12 +6,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.1/dist/css/bootstrap.min.css">
   <link rel="stylesheet" href="https://cdn.form.io/formiojs/formio.full.min.css">
+  <script type="module" src="addKeySetter.js"></script>
   <title>Demo</title>
 </head>
 
 <body>
   <div id="root"></div>
-  <script type="module" src="/src/main.tsx"></script>
+  <script defer type="module" src="/src/main.tsx"></script>
 </body>
 
 </html>

--- a/src/pages/FormBuilder.tsx
+++ b/src/pages/FormBuilder.tsx
@@ -8,7 +8,6 @@ import { Builder, FORMObject } from "../types/formioTypes";
 import updatedForm from "../api/updateForm";
 import ToggleButton from "../components/prebuilt-formio-components/Toggle.json";
 import Forms from "../components/prebuilt-formio-components/Forms.json";
-// import getAllForms from "../api/getAllForms";
 
 function initialeFormJSONObject() {
     return {
@@ -23,6 +22,8 @@ function initialeFormJSONObject() {
 
 function initialOptionsObject() {
     const temp: Builder = {
+        alwaysConfirmComponentRemoval: true,
+        noDefaultSubmitButton: true,
         builder: {
             custom: {
                 title: "Custom Components",

--- a/src/types/formioTypes.ts
+++ b/src/types/formioTypes.ts
@@ -54,7 +54,7 @@ export interface FORMObject {
     key?: string;
 }
 
-export interface CustomComponentObject{
+export interface CustomComponentObject {
     title: string;
     weight: number;
     components: { [key: string]: CustomComponent; };
@@ -74,6 +74,8 @@ export interface PROJECTObject {
 export interface PROJECTArray extends Array<PROJECTObject> { }
 
 export interface Builder {
+    alwaysConfirmComponentRemoval?: boolean;
+    noDefaultSubmitButton?: boolean;
     builder: {
         custom?: boolean | CustomComponentObject;
         basic?: boolean;


### PR DESCRIPTION
An wrapper logic has been added to override the edit view of a component which prepends a field within API tab. Which is used for setting the Property Name field, That is the key of that component.